### PR TITLE
Harden authentication session and OAuth flows for 0.9.0

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if [ ! -f composer.json ]; then
+  exit 0
+fi
+
+has_composer_script() {
+  php -r '
+    $composer = json_decode(file_get_contents("composer.json"), true);
+    exit(isset($composer["scripts"][$argv[1]]) ? 0 : 1);
+  ' "$1"
+}
+
+run_composer_script() {
+  local script="$1"
+
+  if has_composer_script "$script"; then
+    printf "\n==> composer %s\n" "$script"
+    composer "$script"
+  fi
+}
+
+run_composer_script analyze
+run_composer_script test

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "8.3"
+          - "8.4"
           - "latest"
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 .idea
 .vscode
+.github
+.cache
+.copilot
 /.dev/
 /vendor/
 /tests/Unit/src_test/assegai.json

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ It does not currently provide:
 
 You still own the application flow around it: loading users, choosing when to authenticate, defining routes, and deciding what to do after login succeeds.
 
+## Contribution workflow
+
+For commit and pull request conventions in this repo, see:
+
+- [docs/commit-and-pr-guidelines.md](./docs/commit-and-pr-guidelines.md)
+
 ## Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="https://github.com/assegaiphp/auth/releases"><img alt="Latest release" src="https://img.shields.io/github/v/release/assegaiphp/auth?display_name=tag&sort=semver&style=flat-square"></a>
   <a href="https://github.com/assegaiphp/auth/actions/workflows/php.yml"><img alt="Tests" src="https://img.shields.io/github/actions/workflow/status/assegaiphp/auth/php.yml?branch=main&label=tests&style=flat-square"></a>
-  <img alt="PHP 8.3+" src="https://img.shields.io/badge/PHP-8.3%2B-777BB4?style=flat-square&logo=php&logoColor=white">
+  <img alt="PHP 8.4+" src="https://img.shields.io/badge/PHP-8.4%2B-777BB4?style=flat-square&logo=php&logoColor=white">
   <a href="https://github.com/assegaiphp/auth/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/assegaiphp/auth?style=flat-square"></a>
   <img alt="Status active" src="https://img.shields.io/badge/status-active-10b981?style=flat-square">
 </p>

--- a/composer.json
+++ b/composer.json
@@ -19,16 +19,13 @@
     }
   ],
   "require": {
-    "php": ">=8.3",
+    "php": ">=8.4",
     "firebase/php-jwt": "^7.0",
     "assegaiphp/attributes": "^1.0"
   },
   "config": {
     "allow-plugins": {
       "pestphp/pest-plugin": true
-    },
-    "platform": {
-      "php": "8.3.0"
     }
   },
   "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "55082a5c7afb390d3a184d45dcc7489c",
+    "content-hash": "a6cd5c5398a9148467b8aca107c44e89",
     "packages": [
         {
             "name": "assegaiphp/attributes",
@@ -55,12 +55,12 @@
             "version": "v7.0.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/firebase/php-jwt.git",
+                "url": "https://github.com/googleapis/php-jwt.git",
                 "reference": "47ad26bab5e7c70ae8a6f08ed25ff83631121380"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/47ad26bab5e7c70ae8a6f08ed25ff83631121380",
+                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/47ad26bab5e7c70ae8a6f08ed25ff83631121380",
                 "reference": "47ad26bab5e7c70ae8a6f08ed25ff83631121380",
                 "shasum": ""
             },
@@ -4105,11 +4105,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.3"
+        "php": ">=8.4"
     },
     "platform-dev": {},
-    "platform-overrides": {
-        "php": "8.3.0"
-    },
     "plugin-api-version": "2.9.0"
 }

--- a/docs/commit-and-pr-guidelines.md
+++ b/docs/commit-and-pr-guidelines.md
@@ -1,0 +1,59 @@
+# Commit And PR Guidelines
+
+Use this format for `assegaiphp/auth` commits and pull requests.
+
+## Commits
+
+Prefer small, single-purpose commits:
+
+```text
+type(scope): short summary
+```
+
+Examples:
+
+```text
+fix(auth): preserve session state during logout
+feature(auth): add OAuth provider configuration checks
+test(auth): cover JWT strategy expiration handling
+docs(auth): clarify standalone auth usage
+```
+
+Recommended types:
+
+- `fix`
+- `feature`
+- `docs`
+- `test`
+- `refactor`
+- `chore`
+
+If the summary needs "and" to describe unrelated work, split the commit.
+
+## Pull Requests
+
+Every PR should clearly answer:
+
+1. which milestone it belongs to
+2. why it belongs there
+3. what changed
+4. what did not change
+5. how it was verified
+
+Use the repository PR template and keep the body concise.
+
+## Verification
+
+The default check for this repo is:
+
+- `composer test`
+
+Add any extra manual verification that matters for the changed behavior.
+
+## Release Notes
+
+Use:
+
+- `Release notes: Not needed` for internal refactors, tests, and narrow fixes
+- `Release notes: Needed` for user-visible behavior changes
+- `Upgrade notes: Needed` when users may need to change code, config, workflow, or expectations

--- a/meta/repo-health.json
+++ b/meta/repo-health.json
@@ -1,7 +1,7 @@
 {
   "repository": "assegaiphp/auth",
   "package": "assegaiphp/auth",
-  "php": ">=8.3",
+  "php": ">=8.4",
   "license": "MIT",
   "ci": {
     "workflow": "php.yml",

--- a/src/OAuth/OAuth2AuthStrategy.php
+++ b/src/OAuth/OAuth2AuthStrategy.php
@@ -69,13 +69,15 @@ class OAuth2AuthStrategy
       throw new OAuthStateException('OAuth callback is missing the state value.');
     }
 
-    $codeVerifier = $this->stateStore->consume($this->provider->getName(), $state);
+    $storedVerifier = $this->stateStore->consume($this->provider->getName(), $state);
 
-    if ($this->usePkce && $codeVerifier === null) {
+    if ($storedVerifier === null) {
       throw new OAuthStateException('Invalid or expired OAuth state.');
     }
 
-    if (!$this->usePkce && $codeVerifier === null) {
+    $codeVerifier = $storedVerifier === '' ? null : $storedVerifier;
+
+    if ($this->usePkce && $codeVerifier === null) {
       throw new OAuthStateException('Invalid or expired OAuth state.');
     }
 

--- a/src/OAuth/State/SessionOAuthStateStore.php
+++ b/src/OAuth/State/SessionOAuthStateStore.php
@@ -35,9 +35,13 @@ class SessionOAuthStateStore implements OAuthStateStoreInterface
 
     unset($_SESSION[self::SESSION_KEY][$provider]);
 
-    return isset($stored['code_verifier']) && is_string($stored['code_verifier'])
+    if (!array_key_exists('code_verifier', $stored)) {
+      return null;
+    }
+
+    return is_string($stored['code_verifier'])
       ? $stored['code_verifier']
-      : null;
+      : '';
   }
 
   protected function ensureSessionStarted(): void

--- a/src/Strategies/JwtAuthStrategy.php
+++ b/src/Strategies/JwtAuthStrategy.php
@@ -145,6 +145,11 @@ class JwtAuthStrategy implements AuthStrategyInterface
 
     try {
       $decoded = JWT::decode($token, new Key($this->secretKey, $this->algorithm));
+
+      if (!$this->hasValidRegisteredClaims($decoded)) {
+        return false;
+      }
+
       $this->user = $decoded;
       $this->token = $token;
     } catch (Exception) {
@@ -249,6 +254,38 @@ class JwtAuthStrategy implements AuthStrategyInterface
     }
 
     return $timestamp;
+  }
+
+  protected function hasValidRegisteredClaims(stdClass $decoded): bool
+  {
+    if ($this->issuer !== '' && (($decoded->iss ?? null) !== $this->issuer)) {
+      return false;
+    }
+
+    if ($this->audience !== '' && !$this->audienceMatches($decoded->aud ?? null)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  protected function audienceMatches(mixed $audienceClaim): bool
+  {
+    if (is_string($audienceClaim)) {
+      return $audienceClaim === $this->audience;
+    }
+
+    if (!is_array($audienceClaim)) {
+      return false;
+    }
+
+    foreach ($audienceClaim as $candidate) {
+      if (is_string($candidate) && $candidate === $this->audience) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   protected function resolveBearerToken(): ?string

--- a/src/Strategies/SessionAuthStrategy.php
+++ b/src/Strategies/SessionAuthStrategy.php
@@ -104,6 +104,7 @@ class SessionAuthStrategy implements AuthStrategyInterface
   public function establishAuthenticatedUser(object $user): void
   {
     $this->ensureSessionStarted();
+    $this->rotateSessionIdentifier();
     $_SESSION[self::SESSION_USER_FIELD] = $this->sanitizeUser($user);
   }
 
@@ -213,6 +214,20 @@ class SessionAuthStrategy implements AuthStrategyInterface
 
     if (false === session_start($sessionOptions)) {
       throw new AuthException('Failed to start the session.');
+    }
+  }
+
+  /**
+   * @throws AuthException
+   */
+  protected function rotateSessionIdentifier(): void
+  {
+    if ($this->shouldUsePseudoSession() || session_status() !== PHP_SESSION_ACTIVE) {
+      return;
+    }
+
+    if (false === session_regenerate_id(true)) {
+      throw new AuthException('Failed to rotate the session identifier.');
     }
   }
 

--- a/tests/Unit/JwtAuthStrategyTest.php
+++ b/tests/Unit/JwtAuthStrategyTest.php
@@ -63,6 +63,46 @@ it('can validate the issued token', function () {
   expect($strategy->isAuthenticated())->toBeTrue();
 });
 
+it('rejects tokens with a mismatched issuer', function () {
+  $issuer = new JwtAuthStrategy([
+    'secret_key' => $this->secret,
+    'issuer' => 'service-a',
+    'user' => $this->user,
+  ]);
+
+  $token = $issuer->issueTokenForUser($this->user);
+
+  $consumer = new JwtAuthStrategy([
+    'secret_key' => $this->secret,
+    'issuer' => 'service-b',
+    'token' => $token,
+    'user' => $this->user,
+  ]);
+
+  expect($consumer->isAuthenticated())->toBeFalse();
+});
+
+it('rejects tokens with a mismatched audience', function () {
+  $issuer = new JwtAuthStrategy([
+    'secret_key' => $this->secret,
+    'issuer' => 'service-a',
+    'audience' => 'frontend',
+    'user' => $this->user,
+  ]);
+
+  $token = $issuer->issueTokenForUser($this->user);
+
+  $consumer = new JwtAuthStrategy([
+    'secret_key' => $this->secret,
+    'issuer' => 'service-a',
+    'audience' => 'backoffice',
+    'token' => $token,
+    'user' => $this->user,
+  ]);
+
+  expect($consumer->isAuthenticated())->toBeFalse();
+});
+
 it('throws for malformed credentials', function () {
   $strategy = new JwtAuthStrategy([
     'secret_key' => $this->secret,

--- a/tests/Unit/OAuth2AuthStrategyTest.php
+++ b/tests/Unit/OAuth2AuthStrategyTest.php
@@ -146,6 +146,66 @@ it('can handle a callback and establish session and jwt auth', function () {
     ->and($sessionStrategy->getUser())->toHaveProperty('email', 'oauth@example.com');
 });
 
+it('can handle a callback without pkce when the state is valid', function () {
+  $stateStore = new class implements OAuthStateStoreInterface {
+    public function store(string $provider, string $state, ?string $codeVerifier = null): void
+    {
+    }
+
+    public function consume(string $provider, string $state): ?string
+    {
+      return '';
+    }
+  };
+
+  $provider = new class implements OAuthProviderInterface {
+    public function getName(): string
+    {
+      return 'github';
+    }
+
+    public function buildAuthorizationUrl(OAuthProviderConfig $config, string $state, ?string $codeChallenge = null, string $codeChallengeMethod = 'S256'): string
+    {
+      return 'https://example.test/authorize';
+    }
+
+    public function exchangeCode(OAuthProviderConfig $config, string $code, ?string $codeVerifier = null): OAuthTokenResponse
+    {
+      expect($code)->toBe('callback-code')
+        ->and($codeVerifier)->toBeNull();
+
+      return new OAuthTokenResponse('access-token');
+    }
+
+    public function fetchUserProfile(OAuthProviderConfig $config, OAuthTokenResponse $tokens): OAuthUserProfile
+    {
+      return new OAuthUserProfile(
+        provider: 'github',
+        providerId: '123',
+        email: 'oauth@example.com',
+        name: 'OAuth User',
+        username: 'oauth-user',
+      );
+    }
+  };
+
+  $strategy = new OAuth2AuthStrategy(
+    provider: $provider,
+    config: new OAuthProviderConfig('id', 'secret', 'https://app/callback', 'https://auth', 'https://token', 'https://user'),
+    stateStore: $stateStore,
+    usePkce: false,
+  );
+
+  $result = $strategy->handleCallback([
+    'code' => 'callback-code',
+    'state' => 'state-123',
+  ]);
+
+  expect($result->sessionEstablished)->toBeFalse()
+    ->and($result->jwtToken)->toBeNull()
+    ->and($result->user)->toHaveProperty('email', 'oauth@example.com');
+});
+
 it('rejects invalid callback state', function () {
   $strategy = new OAuth2AuthStrategy(
     provider: new class implements OAuthProviderInterface {

--- a/tests/Unit/SessionAuthStrategyTest.php
+++ b/tests/Unit/SessionAuthStrategyTest.php
@@ -46,6 +46,20 @@ it('can authenticate a user', function () {
   ]))->toBeTrue();
 });
 
+it('rotates the session identifier after credential authentication', function () {
+  $knownSessionId = session_create_id('auth-');
+  session_id($knownSessionId);
+
+  $strategy = new SessionAuthStrategy(['user' => $this->user]);
+
+  expect($strategy->authenticate([
+    'email' => $this->email,
+    'password' => $this->password,
+  ]))->toBeTrue()
+    ->and(session_status())->toBe(PHP_SESSION_ACTIVE)
+    ->and(session_id())->not->toBe($knownSessionId);
+});
+
 it('fails when the password is wrong', function () {
   $strategy = new SessionAuthStrategy(['user' => $this->user]);
 
@@ -99,6 +113,21 @@ it('can establish a trusted authenticated user directly', function () {
   expect($strategy->isAuthenticated())->toBeTrue()
     ->and($strategy->getUser())
     ->toHaveProperty('email', 'oauth@example.com');
+});
+
+it('rotates the session identifier when establishing a trusted user', function () {
+  $knownSessionId = session_create_id('auth-');
+  session_id($knownSessionId);
+
+  $strategy = new SessionAuthStrategy(['user' => $this->user]);
+  $strategy->establishAuthenticatedUser((object) [
+    'id' => 99,
+    'email' => 'oauth@example.com',
+    'name' => 'OAuth User',
+  ]);
+
+  expect(session_status())->toBe(PHP_SESSION_ACTIVE)
+    ->and(session_id())->not->toBe($knownSessionId);
 });
 
 it('can logout a user', function () {

--- a/tests/Unit/SessionOAuthStateStoreTest.php
+++ b/tests/Unit/SessionOAuthStateStoreTest.php
@@ -28,6 +28,14 @@ it('stores and consumes state once', function () {
     ->and($store->consume('github', 'state-123'))->toBeNull();
 });
 
+it('returns an empty verifier sentinel for a valid non-pkce state', function () {
+  $store = new SessionOAuthStateStore();
+  $store->store('github', 'state-123');
+
+  expect($store->consume('github', 'state-123'))->toBe('')
+    ->and($store->consume('github', 'state-123'))->toBeNull();
+});
+
 it('returns null for an invalid state', function () {
   $store = new SessionOAuthStateStore();
   $store->store('github', 'state-123', 'verifier-123');


### PR DESCRIPTION
This pull request introduces several important improvements and fixes across authentication strategies, project requirements, and developer workflow. The most significant changes include enforcing stricter PHP version requirements, enhancing JWT and session authentication security, clarifying contribution guidelines, and improving OAuth2 PKCE handling.

**Authentication strategy improvements:**

* JWT authentication now strictly validates the `issuer` and `audience` claims, rejecting tokens that do not match the expected values. New tests ensure these checks work as intended. (`src/Strategies/JwtAuthStrategy.php`, `tests/Unit/JwtAuthStrategyTest.php`) [[1]](diffhunk://#diff-d90dee71738bbdd8135dc71a221ab89a4f4c451019f763c3a3e092d24e769430R148-R152) [[2]](diffhunk://#diff-d90dee71738bbdd8135dc71a221ab89a4f4c451019f763c3a3e092d24e769430R259-R290) [[3]](diffhunk://#diff-690b22438543aae754227b658c3a4903a175dd3046029ad4c00bd1ccef6be941R66-R105)
* Session authentication now rotates the session identifier both after successful credential authentication and when establishing a trusted user, improving session security. Tests verify this behavior. (`src/Strategies/SessionAuthStrategy.php`, `tests/Unit/SessionAuthStrategyTest.php`) [[1]](diffhunk://#diff-69d2e0b3ecdbb5024a8ba02357f82593175fcae02d5815ac185540b632c97f56R107) [[2]](diffhunk://#diff-69d2e0b3ecdbb5024a8ba02357f82593175fcae02d5815ac185540b632c97f56R220-R233) [[3]](diffhunk://#diff-7bae750a057e80463e6fb3451234cd9ad249c5bf3699b2bc1e5218bf9cc0193eR49-R62) [[4]](diffhunk://#diff-7bae750a057e80463e6fb3451234cd9ad249c5bf3699b2bc1e5218bf9cc0193eR118-R132)
* OAuth2 PKCE state handling is fixed to distinguish between missing and intentionally empty code verifiers, with updated logic and new tests. (`src/OAuth/OAuth2AuthStrategy.php`, `src/OAuth/State/SessionOAuthStateStore.php`, `tests/Unit/OAuth2AuthStrategyTest.php`, `tests/Unit/SessionOAuthStateStoreTest.php`) [[1]](diffhunk://#diff-eef89eea42b3799f47cfabb812dffc9c4f44fa7d6651867a660640400fc1b433L72-R80) [[2]](diffhunk://#diff-3307c4346babb5e5315e9e86c4be7ab52961367c4d32e7e2d2fb55dc3ded0b7fL38-R44) [[3]](diffhunk://#diff-9243eacfd1705a9e1e2a7b1c6d1aaf3f4a30aa124b7c2451059e0d5a02bba01fR149-R208) [[4]](diffhunk://#diff-16099afa8a3f5cfd1540b474f61b4472cacbbeebc7ca3cb3f8c26cffa2079143R31-R38)

**Project requirements and workflow:**

* The minimum required PHP version is now 8.4, reflected in `composer.json`, CI workflow, badges, and metadata. (`composer.json`, `.github/workflows/php.yml`, `README.md`, `meta/repo-health.json`) [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L22-L31) [[2]](diffhunk://#diff-a73bb6555480a5ee79ae276a3f5d71a08fa316e09a4a8da7b643cf1e92c97df9L19-R19) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R10) [[4]](diffhunk://#diff-d7368a10764af1064d0004a7e104592d7a1760efc652228ad8dfc21459a13e41L4-R4)
* A pre-push git hook is added to automatically run `composer analyze` and `composer test` before pushing changes, helping maintain code quality. (`.githooks/pre-push`)

**Developer documentation:**

* New contribution guidelines detail commit and pull request conventions, verification steps, and release note practices. The `README.md` is updated to reference these guidelines. (`docs/commit-and-pr-guidelines.md`, `README.md`) [[1]](diffhunk://#diff-bbce47aee4a1d5db1813fb8b92c1197903d91f3fad23c29d0dab74f6a7ee903eR1-R59) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R48-R53)